### PR TITLE
Update layout for longer package names

### DIFF
--- a/atmosphere.css
+++ b/atmosphere.css
@@ -79,6 +79,36 @@ li {
   text-align: left;
 }
 
+.packages td {
+    padding: 5px;
+}
+
+dl.package-title {
+    margin: 0;
+    padding: 0;
+}
+
+.package-title dt {
+  font-weight: bold;
+}
+
+.package-title dd {
+  color: #777;
+}
+
+dl.version-title {
+    margin: 0;
+    padding: 0;
+}
+
+.version-title dt {
+    font-weight: bold;
+}
+
+.version-title dd {
+    color: #777;
+}
+
 td.info-cell {
   vertical-align: top;
 }

--- a/atmosphere.html
+++ b/atmosphere.html
@@ -48,22 +48,28 @@
       <table class="packages table-striped">
         <thead>
           <tr>
-            <th>Name</th>
-            <th>Description</th>
-            <th>Current</th>
-            <th>Updated</th>
-            <th></th>
+            <th>Smart Package</th>
+            <th>Version</th>
+            <th>&nbsp;</th>
           </tr>
         </thead>
         <tbody>
           {{#each packages}}
           <tr>
-            <td><a href="{{homepage}}">{{trunc name 20}}</a></td>
-            <td>{{trunc description 55}}</td>
-            <td>v{{latest}}</td>
             <td>
-              {{refreshEvery "15s"}}
-              <span class="timeAgo">{{timeAgo}}</span>
+                <dl class="package-title">
+                    <dt><a href="{{homepage}}">{{trunc name 80}}</a></dt>
+                    <dd>{{trunc description 95}}</dd>
+                </dl>
+            </td>
+            <td>
+                <dl class="version-title">
+                    <dt>v{{latest}}</dt>
+                    <dd>
+                        {{refreshEvery "15s"}}
+                        <span class="timeAgo">{{timeAgo}}</span>
+                    </dd>
+                </dl>
             </td>
             <td class="info-cell">
               <a class="btn btn-mini details"><i class="icon-info-sign"></i> Info</a>


### PR DESCRIPTION
Quick pass at new layout to better display packages with long names. Please double-check the date rendering - on my test setup all the packages are listed as 'a few seconds ago'. I'm assuming this is the auth date bug rearing its head again.
