### PR TITLE
Ensure no two packages have the same git URL

### DIFF
--- a/app/server/methods.js
+++ b/app/server/methods.js
@@ -27,6 +27,14 @@ Meteor.methods({
       // Name
       _.presenceOf   ('name'),
       _.lengthOf     ('name', { gte: 1, lte: 30 }),
+      function(doc){  
+        if(doc.name != null && doc.name.indexOf(" ") != -1){   
+            return {
+                field: 'name',
+                message: 'You cannot have spaces in your package name.'
+            };
+        }
+      }
 
       // Description
       _.presenceOf   ('description'),


### PR DESCRIPTION
Issue can be found here:
https://atmosphere.meteor.com/package/Amazon%20S3%20File%20Uploader
is the same as
https://atmosphere.meteor.com/package/s3

We need to combat duplicate uploads by identifying packages by their git url, not by their name. To avoid breaking any current functionality, this commit attempts to fix this issue (with a temporary solution) by checking the uniqueness of the git url.
