### PR TITLE
#81: added 'router', 'page-js-ie-support' and 'HTML5-History-API' to smart.lock

### DIFF
--- a/app/smart.lock
+++ b/app/smart.lock
@@ -13,6 +13,11 @@
         "tag": "v2.2.1",
         "commit": "9ee12e714afe56b189f53076447b7b54f3012065"
       },
+      "router": {
+        "git": "https://github.com/tmeasday/meteor-router.git",
+        "tag": "v0.5.4.1",
+        "commit": "d00e380dda2184b70e909fc4a0fb5358d602c586"
+      },
       "fast-render": {
         "git": "https://github.com/arunoda/meteor-fast-render.git",
         "tag": "v0.1.9",
@@ -22,6 +27,16 @@
         "git": "https://github.com/Tarangp/Meteor-Analytics.git",
         "tag": "v0.3.5",
         "commit": "abc2bff0d326af01f9a23e7f1c916e7653b1eb4c"
+      },
+      "page-js-ie-support": {
+        "git": "https://github.com/tmeasday/meteor-page-js-ie-support.git",
+        "tag": "v1.3.5",
+        "commit": "b99ed8380aefd10b2afc8f18d9eed4dd0d8ea9cb"
+      },
+      "HTML5-History-API": {
+        "git": "https://github.com/tmeasday/meteor-HTML5-History-API.git",
+        "tag": "v4.0.0",
+        "commit": "dc4965f1424cfca625ec3fbea17eace03f8e32c5"
       }
     }
   }


### PR DESCRIPTION
Fix for #81 . This `smart.lock` works on my Debian 7.
